### PR TITLE
docs: ACPをAmiVoice APIに変更

### DIFF
--- a/SpeakerDiarizationSampleApp/README.md
+++ b/SpeakerDiarizationSampleApp/README.md
@@ -1,5 +1,5 @@
 # SpeakerDiarizationSampleApp
-AmiVoice Cloud Platformの非同期HTTP音声認識APIにおける話者ダイアライゼーションを使用したWindowsアプリ
+AmiVoice APIの非同期HTTP音声認識APIにおける話者ダイアライゼーションを使用したWindowsアプリケーション
 
 ## About
 複数人が話している会議の録音した音声ファイルをアップロードするだけで、自動的に発言者ごとに区別して、文字起こしすることができます。


### PR DESCRIPTION
## 変更点
AmiVoice Cloud Platformの位置づけが変わり、AmiVoice APIを含む開発用のサービスの総称となったのでREADMEを変更します。

（@m-hayashi13 さんをReviewerに設定できなかったのでここでメンションしました。）